### PR TITLE
Rename the throttle function to debounce

### DIFF
--- a/src/_posts/2018-04-18-how-a-javascript-debounce-function-works.md
+++ b/src/_posts/2018-04-18-how-a-javascript-debounce-function-works.md
@@ -43,7 +43,7 @@ It's common practice to use either a debounce or throttle to limit the amount of
 If we were to apply our debounce method to the above scroll listener, it would look like this:
 
 ```js
-window.addEventListener('scroll', throttle(() => {
+window.addEventListener('scroll', debounce(() => {
 	// Check how far the user has scrolled
 }, 500));
 ```


### PR DESCRIPTION
I think this example should read `debounce`, since the description under the example states that the handler should fire _after_ the scrolling has finished (hence it no longer _debounces_) instead of being throttled.